### PR TITLE
refactor: Repo Id as input

### DIFF
--- a/.changeset/healthy-bikes-behave.md
+++ b/.changeset/healthy-bikes-behave.md
@@ -2,4 +2,4 @@
 '@protocol.land/sync-github': patch
 ---
 
-refactor: Accept repo id as inputs
+refactor: Accept repo id as inputs & update sync url

--- a/.changeset/healthy-bikes-behave.md
+++ b/.changeset/healthy-bikes-behave.md
@@ -1,0 +1,5 @@
+---
+'@protocol.land/sync-github': patch
+---
+
+refactor: Accept repo id as inputs

--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ To synchronize your Protocol Land repository with GitHub, you'll need to configu
 
 - Navigate to your GitHub repository's **Settings > Secrets and variables > Actions > New Repository Secret**.
 - **(Optional)** For syncing private repositories, add a new secret named **`WALLET`** with your Arweave wallet's JWK as the value.
-- Add a new secret named **`PL_REPO_ID`** with your Protocol Land Repository ID as the value. Your Protocol Land Repo ID can be found in the repository's URL, e.g., **`6ace6247-d267-463d-b5bd-7e50d98c3693`**.
 - You'll also need a Personal Access Token (PAT) with the appropriate permissions to sync from Protocol Land to GitHub. To create PAT, goto [Fine-grained tokens](https://github.com/settings/tokens?type=beta) to create a PAT. Set a token name, expiration, repository access `(All repositories or Only select repositories (Recommended))` and permissions `(Repository permissions -> Contents -> Read and write, Repository permissions -> Workflows -> Read and write)`. Finally, add a new secret named **`WORKFLOW_TOKEN`** with your PAT created as the value.
 
 3. **Setting Up the GitHub Workflow**:
@@ -42,6 +41,9 @@ on:
         description: "Force push"
         required: false
         default: "false"
+      repoId:
+        description: "Protocol Land Repo Id"
+        required: true
 
 permissions:
   contents: write
@@ -57,7 +59,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.WORKFLOW_TOKEN || secrets.GITHUB_TOKEN }}
           WALLET: ${{ secrets.WALLET }}
-          PL_REPO_ID: ${{ secrets.PL_REPO_ID }}
+          PL_REPO_ID: ${{ inputs.repoId }}
           FORCE_PUSH: ${{ inputs.forcePush }}
           GH_REPO_NAME: ${{ github.repository }}
 ```

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ jobs:
 
 2. **Configuring Protocol Land Repository Settings**:
 
-![image](https://github.com/labscommunity/protocol-land-sync-github/assets/11836100/65483d12-eb1b-4453-b584-55709dce8562)
+![image](https://github.com/labscommunity/protocol-land-sync-github/assets/11836100/ff2ce620-1efc-4989-bfa3-3960befdaac3)
 
 Goto repository settings on Protocol Land. Then configure the following:
 

--- a/src/lib/warpHelper.ts
+++ b/src/lib/warpHelper.ts
@@ -28,8 +28,10 @@ export async function getRepo(id: string, destpath?: string) {
     let pl = getWarp(destpath).contract(CONTRACT_TXID);
 
     await pl
-        .syncState('https://dre-1.warp.cc/contract', { validity: true })
-        .catch((err: any) => console.log('DRE Sync Error: ', err?.message));
+        .syncState('https://pl-cache.saikranthi.dev/contract', {
+            validity: true,
+        })
+        .catch(() => {});
 
     // let warp throw error if it can't retrieve the repository
     const response = await pl.viewState({


### PR DESCRIPTION
# Summary

This PR updates the workflow to include `repoId` as input so we can eliminate a step to configure the `PL_REPO_ID` manually.

Related:
https://github.com/labscommunity/protocol-land/pull/96
https://github.com/labscommunity/protocol-land-remote-helper/pull/25